### PR TITLE
Fixed image centering issue in centered-image shortcode

### DIFF
--- a/layouts/shortcodes/centered-image.html
+++ b/layouts/shortcodes/centered-image.html
@@ -1,8 +1,3 @@
-<!-- <figure style="text-align:center; display: block; margin-left: auto; margin-right: auto; margin-top: 0em; margin-bottom: 2em; width: 100%;{{ with .Get "width" }}
-max-width: {{ . }};{{ end }}">
-<img src="{{ .Get "src" }}" {{ with .Get "alt" }}alt="{{ . }}"{{ end }} style="margin:0em;"/>
-{{ if .Get "showCaption" }}{{ with .Get "alt" }}<figcaption style="font-style: italic; font-size: 0.8rem">{{ . }}</figcaption>{{ end }}{{ end }}
-</figure> -->
 <figure style="text-align: center; display: block; margin-left: auto; margin-right: auto; margin-top: 0em; margin-bottom: 2em; width: 100%; {{ with .Get "width" }} max-width: {{ . }};{{ end }}">
   <img src="{{ .Get "src" }}" {{ with .Get "alt" }}alt="{{ . }}"{{ end }} style="display: block; margin-left: auto; margin-right: auto; width: 100%; height: auto;" />
   {{ if .Get "showCaption" }}{{ with .Get "alt" }}

--- a/layouts/shortcodes/centered-image.html
+++ b/layouts/shortcodes/centered-image.html
@@ -1,5 +1,11 @@
-<figure style="text-align:center; display: block; margin-left: auto; margin-right: auto; margin-top: 0em; margin-bottom: 2em; width: 100%;{{ with .Get "width" }}
+<!-- <figure style="text-align:center; display: block; margin-left: auto; margin-right: auto; margin-top: 0em; margin-bottom: 2em; width: 100%;{{ with .Get "width" }}
 max-width: {{ . }};{{ end }}">
 <img src="{{ .Get "src" }}" {{ with .Get "alt" }}alt="{{ . }}"{{ end }} style="margin:0em;"/>
 {{ if .Get "showCaption" }}{{ with .Get "alt" }}<figcaption style="font-style: italic; font-size: 0.8rem">{{ . }}</figcaption>{{ end }}{{ end }}
+</figure> -->
+<figure style="text-align: center; display: block; margin-left: auto; margin-right: auto; margin-top: 0em; margin-bottom: 2em; width: 100%; {{ with .Get "width" }} max-width: {{ . }};{{ end }}">
+  <img src="{{ .Get "src" }}" {{ with .Get "alt" }}alt="{{ . }}"{{ end }} style="display: block; margin-left: auto; margin-right: auto; width: 100%; height: auto;" />
+  {{ if .Get "showCaption" }}{{ with .Get "alt" }}
+  <figcaption style="font-style: italic; font-size: 0.8rem; text-align: center;">{{ . }}</figcaption>
+  {{ end }}{{ end }}
 </figure>


### PR DESCRIPTION
Fixes #106 

This PR fixes the issue where images using the centered-image shortcode were not properly centered in all layouts. The existing <figure> tag structure was retained, but the CSS was updated to ensure consistent centering.

Testing:
Verified locally by rendering the post with the affected image, ensuring the image is centered as expected in all screen sizes and layouts.

![image](https://github.com/user-attachments/assets/ac8d8863-2c5c-41b9-9aa3-7bff50331811)
