### PR TITLE
#120 Change hover link of OTH Regensburg logo

### DIFF
--- a/data/de/partners.json
+++ b/data/de/partners.json
@@ -21,7 +21,7 @@
     "title": "OTH Regensburg",
     "text": "Die <a class=\"link-purple\" href=\"https://www.oth-regensburg.de\" target=\"_blank\">OTH Regensburg</a> ist eine renommierte technische Hochschule in Deutschland, die eine breite Palette an Studiengängen anbietet, wobei ihr Fachbereich für Informatik und IT besonders hervorzuheben ist durch praxisorientierte Lehrmethoden und enge Zusammenarbeit mit der Industrie. OpenElements ist ein Partner der OTH Regensburg und unser Gründer <a class=\"link-purple\" href=\"/about-hendrik/\">Hendrik Ebbers</a> ist Dozent für Blockchain-Technologie an der OTH.",
     "logo": "/illustrations/logo-oth.svg",
-    "link": "https://swirldslabs.com"
+    "link": "https://www.oth-regensburg.de"
   },
   {
     "title": "TAKKA",

--- a/data/en/partners.json
+++ b/data/en/partners.json
@@ -21,7 +21,7 @@
     "title": "OTH Regensburg",
     "text": "The <a class=\"link-purple\" href=\"https://www.oth-regensburg.de\" target=\"_blank\">OTH Regensburg</a> is a prestigious technical university in Germany, offering a wide range of degree programs, with its department for computer science and IT particularly notable for its practice-oriented teaching methods and close collaboration with the industry. OpenElements is a partner of OTH Regensburg, and our founder <a class=\"link-purple\" href=\"/about-hendrik/\">Hendrik Ebbers</a> is a lecturer for blockchain technology at the OTH.",
     "logo": "/illustrations/logo-oth.svg",
-    "link": "https://swirldslabs.com"
+    "link": "https://www.oth-regensburg.de/en"
   },
   {
     "title": "TAKKA",


### PR DESCRIPTION
### Summary

Update the OTH Regensburg logo URL:

- **German (de)**: Change to `www.oth-regensburg.de`
- **English (en)**: Change to `www.oth-regensburg.de/en`