### PR TITLE
Added Keywords as Metadata to Page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,7 +13,7 @@ languageCode = "en-us"
 languageName = "EN"
 [languages.en.params]
 description = "Open Source made right - Open Elements is a modern company with a clear focus on Open Source and Java"
-keywords = ["open source", "Java", "OSS", "IT company", "software development", "open source consulting", "Java consulting"]
+keywords = ["open source", "Java", "OSS", "open source Support", "Java Support"]
 
 [languages.de]
 weight = 2
@@ -21,8 +21,7 @@ languageCode = "de"
 languageName = "DE"
 [languages.de.params]
 description = "Open Source, aber richtig - Open Elements ist ein modernes Unternehmen mit einem Fokus auf Open Source und Java"
-keywords = ["open source", "Java", "OSS", "IT-Unternehmen", "Softwareentwicklung", "Open-Source-Beratung", "Java-Beratung"]
-
+keywords = ["Open Source", "Java", "OSS", "Open Source Unterstützung", "Java Unterstützung"]
 [markup.goldmark.renderer]
 unsafe = true
 

--- a/config.toml
+++ b/config.toml
@@ -13,6 +13,7 @@ languageCode = "en-us"
 languageName = "EN"
 [languages.en.params]
 description = "Open Source made right - Open Elements is a modern company with a clear focus on Open Source and Java"
+keywords = ["open source", "Java", "OSS", "IT company", "software development", "open source consulting", "Java consulting"]
 
 [languages.de]
 weight = 2
@@ -20,6 +21,7 @@ languageCode = "de"
 languageName = "DE"
 [languages.de.params]
 description = "Open Source, aber richtig - Open Elements ist ein modernes Unternehmen mit einem Fokus auf Open Source und Java"
+keywords = ["open source", "Java", "OSS", "IT-Unternehmen", "Softwareentwicklung", "Open-Source-Beratung", "Java-Beratung"]
 
 [markup.goldmark.renderer]
 unsafe = true

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -2,13 +2,7 @@
 title: "About us"
 description: "An overview of the engagement of OpenElements and its partners and customers."
 layout: "about-us"
-keywords:
-  - about us
-  - Open Elements
-  - Java
-  - OSS
-  - open source
-  - IT company
+keywords: "Java", "Open Source", "OSS", "Open Source Support", "Java Support"
   
 section_intro: '<a class="link-purple" href="/about-hendrik/">Hendrik Ebbers</a> founded the OpenElements GmbH in 2022 to create a company that strengthens open source and open collaboration with a strong focus on the Java ecosystem.'
 

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -2,7 +2,14 @@
 title: "About us"
 description: "An overview of the engagement of OpenElements and its partners and customers."
 layout: "about-us"
-
+keywords:
+  - about us
+  - Open Elements
+  - Java
+  - OSS
+  - open source
+  - IT company
+  
 section_intro: '<a class="link-purple" href="/about-hendrik/">Hendrik Ebbers</a> founded the OpenElements GmbH in 2022 to create a company that strengthens open source and open collaboration with a strong focus on the Java ecosystem.'
 
 section_engagement_title: 'Our Engagements'

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,7 +13,7 @@
   {{ else if .Site.Params.keywords -}}
   <meta name="keywords" content="{{ delimit .Site.Params.keywords ", " }}" />
   {{ else -}}
-  <meta name="keywords" content="open source, Java, OSS, IT company, software development, open source consulting, Java consulting" />
+  <meta name="keywords" content="open source, Java, OSS, open source Support, Java Support" />
   {{ end -}}
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,6 +8,13 @@
   {{ if .Params.Description -}}
   <meta name="description" content="{{ .Params.Description }}" />
   {{ end -}}
+  {{ if .Params.Keywords -}}
+  <meta name="keywords" content="{{ delimit .Params.Keywords ", " }}" />
+  {{ else if .Site.Params.keywords -}}
+  <meta name="keywords" content="{{ delimit .Site.Params.keywords ", " }}" />
+  {{ else -}}
+  <meta name="keywords" content="open source, Java, OSS, IT company, software development, open source consulting, Java consulting" />
+  {{ end -}}
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta http-equiv="x-ua-compatible" content="ie=edge">


### PR DESCRIPTION
cc
@hendrikebbers 
@Jexsie 
As per issue #59, I added the keywords "open source, Java, OSS, IT company, software development, open source consulting and Java consulting" as metadata to the website. Below is the:

## Description of Changes:

In order to add support for meta-keywords to improve SEO for the Open Elements website. I updated the following files:

- **layouts/partials/head.html**:
I added logic to include a <meta name="keywords"> tag.
Keywords are pulled from the page-specific keywords field in the front matter if defined. Otherwise, fallback to global keywords defined in config.toml, or default hardcoded values.

-**config.toml**:
I added global keywords configuration for English and German languages (Hope the German translation is accurate ☺️, if not let me know so that I can make further changes). These keywords serve as defaults if page-specific keywords are not provided.

-**content/index.md**:
I defined specific keywords for the "About Us" page in the front matter.

These changes ensure that each page has an appropriate <meta name="keywords"> tag, improving discoverability and alignment with SEO best practices.

Also attached is a screenshot showing that the metadata keywords are now available in the page source after starting a hugo development server, navigating to the URL provided in the terminal leading to the website and viewing the page source.
Cheers!
![Screenshot from 2024-12-05 19-54-35](https://github.com/user-attachments/assets/14dfc153-b5b7-44c7-abca-8b026c22e564)

