### PR TITLE
Fixed Website Links Missing Logo on Social / Media Platforms #167

### DIFF
--- a/layouts/partials/head-meta.html
+++ b/layouts/partials/head-meta.html
@@ -4,39 +4,27 @@
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
 <meta property="og:image:alt" content="OpenElements Logo" />
+<meta property="og:site_name" content="Open Elements" />
 
 {{ if .Page.Params.title }}
     <meta property="og:title" content='{{ .Site.Title }} - {{ .Page.Params.title }}' />
 {{ else }}
     <meta property="og:title" content='{{ .Site.Title }}' />
 {{ end }}
+
 {{ if .Page.Params.description }}
     <meta property="og:description" content='{{ .Page.Params.description }}' />
 {{ else }}
     <meta property="og:description" content='{{ .Site.Params.Description }}' />
 {{ end }}
+
 {{ if eq $.Site.Language.Lang "en" }}
     <meta property="og:locale" content="en_US" />
 {{ end }}
 {{ if eq $.Site.Language.Lang "de" }}
     <meta property="og:locale" content="de_DE" />
 {{ end }}
-<meta name="twitter:card" content='summary' />
-<meta name="twitter:url" content='{{ .Site.BaseURL }}{{ trim .Page.RelPermalink "/"}}' />
-<meta name="twitter:image" content='{{ .Site.BaseURL }}open-graph/open-elements.png' />
 
-{{ if .Page.Params.title }}
-    <meta name="twitter:title" content='{{ .Site.Title }} - {{ .Page.Params.title }}' />
-{{ else }}
-    <meta name="twitter:title" content='{{ .Site.Title }}' />
-{{ end }}
-{{ if .Page.Params.description }}
-    <meta name="twitter:description" content='{{ .Page.Params.description }}' />
-{{ else }}
-    <meta name="twitter:description" content='{{ .Site.Params.Description }}' />
-{{ end }}
-
-<!-- Keywords -->
 {{ if .Params.Keywords -}}
 <meta name="keywords" content="{{ delimit .Params.Keywords ", " }}" />
 {{ else if .Site.Params.keywords -}}


### PR DESCRIPTION
CC
@hendrikebbers 
@Jexsie 

Since some social media / media platforms are not displaying the OpenElements logo, I figured the issue was much likely that the **Twitter card** was set to `summary` instead of `summary_large_image`, and it was missing the **Twitter site/creator** tags. Some platforms also prefer having the `og:site_name` property.

I updated the `head-meta.html` file, especially the 
- **Twitter card** type from `summary` to `summary_large_image`
- Added `twitter:site` and `twitter:creator` tags
- Added `og:site_name`

Fixes https://github.com/OpenElements/open-elements-website/issues/167