### PR TITLE
feat: implement newsletter page with localization and subscription form

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ src/components     UI components
 src/i18n           next-intl routing/messages helpers
 locales            Translation JSON files
 content            Legacy Hugo Markdown content
-src/layouts        Legacy Hugo templates
 public             Static assets and generated artifacts
 react-src          Web components source (bundled to public/js)
 tests/e2e          Playwright specs

--- a/src/app/[locale]/newsletter/page.tsx
+++ b/src/app/[locale]/newsletter/page.tsx
@@ -1,0 +1,96 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import Image from 'next/image'
+import NewsletterForm from '@/components/newsletter/NewsletterForm'
+
+interface NewsletterPageProps {
+  params: Promise<{
+    locale: string
+  }>
+}
+
+export async function generateMetadata({ params }: NewsletterPageProps): Promise<Metadata> {
+  const { locale } = await params
+
+  if (locale !== 'de') {
+    return {
+      title: 'Page Not Available - Open Elements',
+      description: 'This page is not available in this language',
+    }
+  }
+
+  const title = 'Newsletter - Open Elements'
+  const description = 'Melde dich zu unserem Newsletter an, um auf dem Laufenden zu bleiben.'
+
+  return {
+    title,
+    description,
+    openGraph: {
+      type: 'website',
+      url: 'https://open-elements.com/de/newsletter',
+      title,
+      description,
+      siteName: 'Open Elements',
+      images: [
+        {
+          url: '/open-graph/open-elements.png',
+          width: 1200,
+          height: 630,
+          alt: 'OpenElements Logo',
+        },
+      ],
+      locale: 'de_DE',
+    },
+  }
+}
+
+export default async function NewsletterPage({ params }: NewsletterPageProps) {
+  const { locale } = await params
+
+  if (locale !== 'de') {
+    notFound()
+  }
+
+  return (
+    <div>
+      {/* Hero background */}
+      <div className="absolute left-0 w-full top-0 h-48 -z-10 overflow-hidden">
+        <Image
+          src="/illustrations/hero-bg-2.svg"
+          alt="Hero background"
+          fill
+          className="object-cover"
+          priority
+        />
+      </div>
+
+      <div className="container max-w-sm lg:max-w-7xl md:max-w-2xl sm:max-w-xl sm:w-full">
+        {/* Page title */}
+        <div className="flex items-center justify-center pt-16 pb-4 sm:pt-36 sm:pb-12">
+          <div className="relative flex flex-col items-center justify-center w-full">
+            <h1 className="text-center h1">Unser Newsletter</h1>
+            <Image
+              src="/illustrations/underline.svg"
+              alt="Unterstrich"
+              width={288}
+              height={24}
+              className="absolute w-36 -bottom-3 sm:w-56 shrink-0"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Form section */}
+      <div className="lg:pb-48 sm:pb-32 pb-28">
+        <div className="container mt-12 xl:max-w-1xl">
+          <div className="flex flex-col items-center justify-center gap-8">
+            <p className="text-center text-blue max-w-xl text-lg">
+              Bleib auf dem Laufenden über Open Source, Java und die neuesten Nachrichten von Open Elements.
+            </p>
+            <NewsletterForm />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/newsletter/NewsletterForm.tsx
+++ b/src/components/newsletter/NewsletterForm.tsx
@@ -1,0 +1,240 @@
+'use client'
+
+import Script from 'next/script'
+
+const formHtml = `
+<div id="sib-form-container" class="sib-form-container">
+  <div id="error-message" class="sib-form-message-panel"
+       style="font-size:16px; text-align:left; font-family:Helvetica, sans-serif; color:#661d1d; background-color:#ffeded; border-radius:3px; border-color:#ff4949;max-width:540px;">
+    <div class="sib-form-message-panel__text sib-form-message-panel__text--center">
+      <svg viewBox="0 0 512 512" class="sib-icon sib-notification__icon">
+        <path d="M256 40c118.621 0 216 96.075 216 216 0 119.291-96.61 216-216 216-119.244 0-216-96.562-216-216 0-119.203 96.602-216 216-216m0-32C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm-11.49 120h22.979c6.823 0 12.274 5.682 11.99 12.5l-7 168c-.268 6.428-5.556 11.5-11.99 11.5h-8.979c-6.433 0-11.722-5.073-11.99-11.5l-7-168c-.283-6.818 5.167-12.5 11.99-12.5zM256 340c-15.464 0-28 12.536-28 28s12.536 28 28 28 28-12.536 28-28-12.536-28-28-28z"/>
+      </svg>
+      <span class="sib-form-message-panel__inner-text">
+        Deine Anmeldung konnte nicht gespeichert werden. Bitte versuche es erneut.
+      </span>
+    </div>
+  </div>
+  <div></div>
+  <div id="success-message" class="sib-form-message-panel"
+       style="font-size:16px; text-align:left; font-family:Helvetica, sans-serif; color:#085229; background-color:#e7faf0; border-radius:3px; border-color:#13ce66;max-width:540px;">
+    <div class="sib-form-message-panel__text sib-form-message-panel__text--center">
+      <svg viewBox="0 0 512 512" class="sib-icon sib-notification__icon">
+        <path d="M256 8C119.033 8 8 119.033 8 256s111.033 248 248 248 248-111.033 248-248S392.967 8 256 8zm0 464c-118.664 0-216-96.055-216-216 0-118.663 96.055-216 216-216 118.664 0 216 96.055 216 216 0 118.663-96.055 216-216 216zm141.63-274.961L217.15 376.071c-4.705 4.667-12.303 4.637-16.97-.068l-85.878-86.572c-4.667-4.705-4.637-12.303.068-16.97l8.52-8.451c4.705-4.667 12.303-4.637 16.97.068l68.976 69.533 163.441-162.13c4.705-4.667 12.303-4.637 16.97.068l8.451 8.52c4.668 4.705 4.637 12.303-.068 16.97z"/>
+      </svg>
+      <span class="sib-form-message-panel__inner-text">
+        Deine Anmeldung war erfolgreich.
+      </span>
+    </div>
+  </div>
+  <div></div>
+  <div id="sib-container" class="sib-container--large sib-container--vertical"
+       style="text-align:center; background-color:rgba(255,255,255,1); max-width:540px; border-radius:3px; border-width:1px; border-color:#C0CCD9; border-style:solid; direction:ltr">
+    <form id="sib-form" method="POST"
+          action="https://83f3e12d.sibforms.com/serve/MUIFAB9sPNc3vI_F5JWU2bS-86BYNSqnfAE1iEffv9m5QAMla1vDwNMH018M6CMOEAayrpPErJwxgmRV2HONP5VCeXqpiRm9pE9PDqyKvT9-mdLefQARE-ZzgPXXqqRU6WUay4AjAXyo3QVaUkuLKJ8Uwi51A4s__AYJERdqu88aZC1bL5ot2NJzfX9lu3oTNSgY6hHDVqr04aOS"
+          data-type="subscription">
+      <div style="padding: 8px 0;">
+        <div class="sib-form-block"
+             style="font-size:16px; text-align:left; font-family:Helvetica, sans-serif; color:#3C4858; background-color:transparent;">
+          <div class="sib-text-form-block">
+            <p>Melde dich zu unserem Newsletter an, um auf dem Laufenden zu bleiben.</p>
+          </div>
+        </div>
+      </div>
+      <div style="padding: 8px 0;">
+        <div class="sib-input sib-form-block">
+          <div class="form__entry entry_block">
+            <div class="form__label-row ">
+              <label class="entry__label"
+                     style="font-weight: 700; text-align:left; font-size:16px; font-family:Helvetica, sans-serif; color:#3c4858;"
+                     for="VORNAME">Gib dein(e) VORNAME ein</label>
+              <div class="entry__field">
+                <input class="input" maxlength="200" type="text" id="VORNAME" name="VORNAME"
+                       autocomplete="off" placeholder="VORNAME" />
+              </div>
+            </div>
+            <label class="entry__error entry__error--primary"
+                   style="font-size:16px; text-align:left; font-family:Helvetica, sans-serif; color:#661d1d; background-color:#ffeded; border-radius:3px; border-color:#ff4949;">
+            </label>
+          </div>
+        </div>
+      </div>
+      <div style="padding: 8px 0;">
+        <div class="sib-input sib-form-block">
+          <div class="form__entry entry_block">
+            <div class="form__label-row ">
+              <label class="entry__label"
+                     style="font-weight: 700; text-align:left; font-size:16px; font-family:Helvetica, sans-serif; color:#3c4858;"
+                     for="NACHNAME">Gib dein(e) NACHNAME ein</label>
+              <div class="entry__field">
+                <input class="input" maxlength="200" type="text" id="NACHNAME" name="NACHNAME"
+                       autocomplete="off" placeholder="NACHNAME" />
+              </div>
+            </div>
+            <label class="entry__error entry__error--primary"
+                   style="font-size:16px; text-align:left; font-family:Helvetica, sans-serif; color:#661d1d; background-color:#ffeded; border-radius:3px; border-color:#ff4949;">
+            </label>
+          </div>
+        </div>
+      </div>
+      <div style="padding: 8px 0;">
+        <div class="sib-input sib-form-block">
+          <div class="form__entry entry_block">
+            <div class="form__label-row ">
+              <label class="entry__label"
+                     style="font-weight: 700; text-align:left; font-size:16px; font-family:Helvetica, sans-serif; color:#3c4858;"
+                     for="EMAIL" data-required="*">Gib deine E-Mail-Adresse ein, um dich anzumelden</label>
+              <div class="entry__field">
+                <input class="input" type="text" id="EMAIL" name="EMAIL" autocomplete="off"
+                       placeholder="EMAIL" data-required="true" required />
+              </div>
+            </div>
+            <label class="entry__error entry__error--primary"
+                   style="font-size:16px; text-align:left; font-family:Helvetica, sans-serif; color:#661d1d; background-color:#ffeded; border-radius:3px; border-color:#ff4949;">
+            </label>
+            <label class="entry__specification"
+                   style="font-size:12px; text-align:left; font-family:Helvetica, sans-serif; color:#8390A4;">
+              Gib bitte deine E-Mail-Adresse für die Anmeldung an, z. B. abc@xyz.com.
+            </label>
+          </div>
+        </div>
+      </div>
+      <div style="padding: 8px 0;">
+        <div class="sib-form-block" style="text-align: left">
+          <button class="sib-form-block__button sib-form-block__button-with-loader"
+                  style="font-size:16px; text-align:left; font-weight:700; font-family:Helvetica, sans-serif; color:#FFFFFF; background-color:#3E4857; border-radius:3px; border-width:0px;"
+                  form="sib-form" type="submit">
+            <svg class="icon clickable__icon progress-indicator__icon sib-hide-loader-icon" viewBox="0 0 512 512">
+              <path d="M460.116 373.846l-20.823-12.022c-5.541-3.199-7.54-10.159-4.663-15.874 30.137-59.886 28.343-131.652-5.386-189.946-33.641-58.394-94.896-95.833-161.827-99.676C261.028 55.961 256 50.751 256 44.352V20.309c0-6.904 5.808-12.337 12.703-11.982 83.556 4.306 160.163 50.864 202.11 123.677 42.063 72.696 44.079 162.316 6.031 236.832-3.14 6.148-10.75 8.461-16.728 5.01z"/>
+            </svg>
+            ANMELDEN
+          </button>
+        </div>
+      </div>
+      <div style="padding: 8px 0;">
+        <div class="sib-form__declaration" style="direction:ltr">
+          <div class="declaration-block-icon">
+            <svg class="icon__SVG" width="0" height="0" version="1.1" xmlns="http://www.w3.org/2000/svg">
+              <defs>
+                <symbol id="svgIcon-sphere" viewBox="0 0 63 63">
+                  <path class="path1" d="M31.54 0l1.05 3.06 3.385-.01-2.735 1.897 1.05 3.042-2.748-1.886-2.738 1.886 1.044-3.05-2.745-1.897h3.393zm13.97 3.019L46.555 6.4l3.384.01-2.743 2.101 1.048 3.387-2.752-2.1-2.752 2.1 1.054-3.382-2.745-2.105h3.385zm9.998 10.056l1.039 3.382h3.38l-2.751 2.1 1.05 3.382-2.744-2.091-2.743 2.091 1.054-3.381-2.754-2.1h3.385zM58.58 27.1l1.04 3.372h3.379l-2.752 2.096 1.05 3.387-2.744-2.091-2.75 2.092 1.054-3.387-2.747-2.097h3.376zm-3.076 14.02l1.044 3.364h3.385l-2.743 2.09 1.05 3.392-2.744-2.097-2.743 2.097 1.052-3.377-2.752-2.117 3.385-.01zm-9.985 9.91l1.045 3.364h3.393l-2.752 2.09 1.05 3.393-2.745-2.097-2.743 2.097 1.05-3.383-2.751-2.1 3.384-.01zM31.45 55.01l1.044 3.043 3.393-.008-2.752 1.9L34.19 63l-2.744-1.895-2.748 1.891 1.054-3.05-2.743-1.9h3.384zm-13.934-3.98l1.036 3.364h3.402l-2.752 2.09 1.053 3.393-2.747-2.097-2.752 2.097 1.053-3.382-2.743-2.1 3.384-.01zm-9.981-9.91l1.045 3.364h3.398l-2.748 2.09 1.05 3.392-2.753-2.1-2.752 2.096 1.053-3.382-2.743-2.102 3.384-.009zM4.466 27.1l1.038 3.372H8.88l-2.752 2.097 1.053 3.387-2.743-2.09-2.748 2.09 1.053-3.387L0 30.472h3.385zm3.069-14.025l1.045 3.382h3.395L9.23 18.56l1.05 3.381-2.752-2.09-2.752 2.09 1.053-3.381-2.744-2.1h3.384zm9.99-10.056L18.57 6.4l3.393.01-2.743 2.1 1.05 3.373-2.754-2.092-2.751 2.092 1.053-3.382-2.744-2.1h3.384zm24.938 19.394l-10-4.22a2.48 2.48 0 00-1.921 0l-10 4.22A2.529 2.529 0 0019 24.75c0 10.47 5.964 17.705 11.537 20.057a2.48 2.48 0 001.921 0C36.921 42.924 44 36.421 44 24.75a2.532 2.532 0 00-1.537-2.336zm-2.46 6.023l-9.583 9.705a.83.83 0 01-1.177 0l-5.416-5.485a.855.855 0 010-1.192l1.177-1.192a.83.83 0 011.177 0l3.65 3.697 7.819-7.916a.83.83 0 011.177 0l1.177 1.191a.843.843 0 010 1.192z" fill="#0092FF"></path>
+                </symbol>
+              </defs>
+            </svg>
+            <svg class="svgIcon-sphere" style="width:63px; height:63px;">
+              <use href="#svgIcon-sphere"></use>
+            </svg>
+          </div>
+          <div style="font-size:14px; text-align:left; font-family:Helvetica, sans-serif; color:#687484; background-color:transparent;">
+            <p>Wir verwenden Brevo als unsere Marketing-Plattform. Indem du das Formular absendest,
+              erklärst du dich einverstanden, dass die von dir angegebenen persönlichen Informationen
+              an Brevo zur Bearbeitung übertragen werden gemäß den <a
+                href="https://www.brevo.com/de/legal/privacypolicy/" target="_blank" rel="noreferrer">Datenschutzrichtlinien
+                von Brevo.</a></p>
+          </div>
+        </div>
+      </div>
+      <input type="text" name="email_address_check" value="" class="input--hidden" />
+      <input type="hidden" name="locale" value="de" />
+    </form>
+  </div>
+</div>
+`
+
+export default function NewsletterForm() {
+  return (
+    <>
+      {/* Brevo form styles */}
+      <style dangerouslySetInnerHTML={{
+        __html: `
+          @font-face {
+            font-display: block;
+            font-family: Roboto;
+            src: url(https://assets.brevo.com/font/Roboto/Latin/normal/normal/7529907e9eaf8ebb5220c5f9850e3811.woff2) format("woff2"),
+                 url(https://assets.brevo.com/font/Roboto/Latin/normal/normal/25c678feafdc175a70922a116c9be3e7.woff) format("woff");
+          }
+          @font-face {
+            font-display: fallback;
+            font-family: Roboto;
+            font-weight: 600;
+            src: url(https://assets.brevo.com/font/Roboto/Latin/medium/normal/6e9caeeafb1f3491be3e32744bc30440.woff2) format("woff2"),
+                 url(https://assets.brevo.com/font/Roboto/Latin/medium/normal/71501f0d8d5aa95960f6475d5487d4c2.woff) format("woff");
+          }
+          @font-face {
+            font-display: fallback;
+            font-family: Roboto;
+            font-weight: 700;
+            src: url(https://assets.brevo.com/font/Roboto/Latin/bold/normal/3ef7cf158f310cf752d5ad08cd0e7e60.woff2) format("woff2"),
+                 url(https://assets.brevo.com/font/Roboto/Latin/bold/normal/ece3a1d82f18b60bcce0211725c476aa.woff) format("woff");
+          }
+          #sib-container input:-ms-input-placeholder {
+            text-align: left;
+            font-family: Helvetica, sans-serif;
+            color: #c0ccda;
+          }
+          #sib-container input::placeholder {
+            text-align: left;
+            font-family: Helvetica, sans-serif;
+            color: #c0ccda;
+          }
+          #sib-container textarea::placeholder {
+            text-align: left;
+            font-family: Helvetica, sans-serif;
+            color: #c0ccda;
+          }
+          #sib-container a {
+            text-decoration: underline;
+            color: #2BB2FC;
+          }
+        `
+      }} />
+
+      {/* Brevo stylesheet */}
+      {/* eslint-disable-next-line @next/next/no-css-tags */}
+      <link rel="stylesheet" href="https://sibforms.com/forms/end-form/build/sib-styles.css" />
+
+      {/* Form */}
+      <div
+        className="sib-form"
+        style={{ textAlign: 'center', backgroundColor: 'transparent' }}
+        dangerouslySetInnerHTML={{ __html: formHtml }}
+      />
+
+      {/* Brevo form JS config */}
+      <Script id="brevo-form-config" strategy="afterInteractive">{`
+        window.REQUIRED_CODE_ERROR_MESSAGE = 'Wähle bitte einen Ländervorwahl aus.';
+        window.LOCALE = 'de';
+        window.EMAIL_INVALID_MESSAGE = window.SMS_INVALID_MESSAGE = "Die eingegebenen Informationen sind nicht gültig. Bitte überprüfe das Feldformat und versuche es erneut.";
+        window.REQUIRED_ERROR_MESSAGE = "Dieses Feld darf nicht leer sein. ";
+        window.GENERIC_INVALID_MESSAGE = "Die eingegebenen Informationen sind nicht gültig. Bitte überprüfe das Feldformat und versuche es erneut.";
+        window.translation = {
+          common: {
+            selectedList: '{quantity} Liste ausgewählt',
+            selectedLists: '{quantity} Listen ausgewählt',
+            selectedOption: '{quantity} ausgewählt',
+            selectedOptions: '{quantity} ausgewählt',
+          }
+        };
+        var AUTOHIDE = Boolean(0);
+      `}</Script>
+
+      {/* Brevo form main script */}
+      <Script
+        src="https://sibforms.com/forms/end-form/build/main.js"
+        strategy="afterInteractive"
+      />
+
+      {/* Brevo SDK loader */}
+      <Script
+        src="https://cdn.brevo.com/js/sdk-loader.js"
+        strategy="afterInteractive"
+      />
+
+      {/* Brevo SDK init */}
+      <Script id="brevo-sdk-init" strategy="afterInteractive">{`
+        window.Brevo = window.Brevo || [];
+        Brevo.push(["init", { client_key: "v3lh6minrpfap69vhy5am8if" }]);
+      `}</Script>
+    </>
+  )
+}


### PR DESCRIPTION
This pull request introduces a new localized newsletter signup page available only in German and implements a custom newsletter signup form using the Brevo (formerly Sendinblue) platform. The changes include both the new page logic and a dedicated React component for rendering and integrating the Brevo form, along with required scripts and styling.

The most important changes are:

**Newsletter Signup Page Implementation**
* Added a new page at `src/app/[locale]/newsletter/page.tsx` that displays the newsletter signup form. The page is only available for the 'de' (German) locale; for all other locales, it returns a not found response. The page also generates locale-specific metadata for SEO and social sharing. ([src/app/[locale]/newsletter/page.tsxR1-R96](diffhunk://#diff-4f3e803b876489b9c0b3ca19cd469777bb1428407ae00dbfcf7f04bd39b67dc4R1-R96))

**Newsletter Form Integration**
* Introduced a new React component `NewsletterForm` in `src/components/newsletter/NewsletterForm.tsx` that renders the Brevo subscription form using raw HTML, includes required Brevo styles and scripts, and initializes the Brevo SDK for form handling and analytics. The form and all messages are fully localized in German.

**Documentation Update**
* Updated the `README.md` to remove the obsolete `src/layouts` entry, reflecting the removal of legacy Hugo templates.