### PR TITLE
Add RSS/Atom feed functionality for blog (#246)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,3 +28,19 @@ unsafe = true
 posts = '/posts/:year/:month/:day/:slug/'
 [permalinks.section]
 posts = '/posts'
+
+[outputs]
+home = ["HTML", "RSS", "Atom"]
+page = ["HTML"]
+section = ["HTML", "RSS", "Atom"]
+
+[mediaTypes."application/atom+xml"]
+suffixes = ["xml"]
+
+[outputFormats.Atom]
+mediaType = "application/atom+xml"
+baseName = "atom"
+isPlainText = false
+
+[services.rss]
+limit = 20

--- a/layouts/_default/atom.xml
+++ b/layouts/_default/atom.xml
@@ -1,0 +1,53 @@
+{{- $pctx := . -}}
+{{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
+{{- $pages := slice -}}
+{{- if or .IsHome .IsSection -}}
+{{- $pages = $pctx.RegularPages -}}
+{{- else -}}
+{{- $pages = $pctx.Pages -}}
+{{- end -}}
+{{- $limit := .Site.Config.Services.RSS.Limit -}}
+{{- if ge $limit 1 -}}
+{{- $pages = $pages | first $limit -}}
+{{- end -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="{{ .Site.Language.Lang }}">
+  <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+  <link href="{{ .Permalink }}" rel="self"/>
+  <link href="{{ .Site.BaseURL }}"/>
+  <updated>{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</updated>
+  <id>{{ .Permalink }}</id>
+  {{- with .Site.Author.name }}
+  <author>
+    <name>{{.}}</name>
+    {{- with $.Site.Author.email }}
+    <email>{{.}}</email>
+    {{- end }}
+  </author>
+  {{- end }}
+  {{- with .Site.Copyright }}
+  <rights>{{ . }}</rights>
+  {{- end }}
+  {{ range $pages }}
+  {{- if and (ne .Layout "search") (ne .Layout "archives") }}
+  <entry>
+    <title>{{ .Title }}</title>
+    <link href="{{ .Permalink }}"/>
+    <id>{{ .Permalink }}</id>
+    <updated>{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</updated>
+    <published>{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</published>
+    {{- with .Site.Author.name }}
+    <author>
+      <name>{{.}}</name>
+    </author>
+    {{- end }}
+    <summary type="html">{{ .Summary | html }}</summary>
+    {{- if .Params.preview_image }}
+    <content type="html">&lt;img src="{{ .Site.BaseURL }}{{ .Params.preview_image }}" alt="{{ .Title }}" /&gt;&lt;br/&gt;{{ .Content | html }}</content>
+    {{- else }}
+    <content type="html">{{ .Content | html }}</content>
+    {{- end }}
+  </entry>
+  {{- end }}
+  {{ end }}
+</feed>

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,0 +1,44 @@
+{{- $pctx := . -}}
+{{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
+{{- $pages := slice -}}
+{{- if or .IsHome .IsSection -}}
+{{- $pages = $pctx.RegularPages -}}
+{{- else -}}
+{{- $pages = $pctx.Pages -}}
+{{- end -}}
+{{- $limit := .Site.Config.Services.RSS.Limit -}}
+{{- if ge $limit 1 -}}
+{{- $pages = $pages | first $limit -}}
+{{- end -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
+    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{- with .OutputFormats.Get "rss" -}}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q>" .Permalink .MediaType | safeHTML }}
+    {{- end -}}
+    {{ range $pages }}
+    {{- if and (ne .Layout "search") (ne .Layout "archives") }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ .Summary | html }}</description>
+      {{- if .Params.preview_image }}
+      <enclosure url="{{ .Site.BaseURL }}{{ .Params.preview_image }}" type="image/svg+xml" />
+      {{- end }}
+    </item>
+    {{- end }}
+    {{ end }}
+  </channel>
+</rss>

--- a/next-app/api/atom/route.js
+++ b/next-app/api/atom/route.js
@@ -1,0 +1,75 @@
+import { NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+
+const postsDirectory = path.join(process.cwd(), 'content/posts');
+
+function getAllPosts() {
+  const slugs = fs.readdirSync(postsDirectory);
+  const posts = slugs
+    .map((slug) => {
+      const fullPath = path.join(postsDirectory, slug);
+      const fileContents = fs.readFileSync(fullPath, 'utf8');
+      const { data, content } = matter(fileContents);
+      
+      return {
+        slug: slug.replace(/\.md$/, ''),
+        frontmatter: data,
+        content,
+        fullPath,
+      };
+    })
+    .filter((post) => post.frontmatter.showInBlog !== false)
+    .sort((a, b) => new Date(b.frontmatter.date) - new Date(a.frontmatter.date));
+  
+  return posts;
+}
+
+function generateAtomFeed(posts) {
+  const siteUrl = 'https://open-elements.com';
+  const feed = `<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
+  <title>Open Elements</title>
+  <link href="${siteUrl}/api/atom" rel="self"/>
+  <link href="${siteUrl}"/>
+  <updated>${new Date().toISOString()}</updated>
+  <id>${siteUrl}/</id>
+  <author>
+    <name>Open Elements</name>
+  </author>
+  ${posts.map(post => `
+  <entry>
+    <title>${post.frontmatter.title}</title>
+    <link href="${siteUrl}/posts/${post.frontmatter.date ? post.frontmatter.date.substring(0, 4) : ''}/${post.frontmatter.date ? post.frontmatter.date.substring(5, 7) : ''}/${post.frontmatter.date ? post.frontmatter.date.substring(8, 10) : ''}/${post.slug}/"/>
+    <id>${siteUrl}/posts/${post.frontmatter.date ? post.frontmatter.date.substring(0, 4) : ''}/${post.frontmatter.date ? post.frontmatter.date.substring(5, 7) : ''}/${post.frontmatter.date ? post.frontmatter.date.substring(8, 10) : ''}/${post.slug}/</id>
+    <updated>${new Date(post.frontmatter.date || post.frontmatter.lastmod).toISOString()}</updated>
+    <published>${new Date(post.frontmatter.date).toISOString()}</published>
+    <author>
+      <name>${post.frontmatter.author || 'Open Elements'}</name>
+    </author>
+    <summary type="html"><![CDATA[${post.frontmatter.excerpt || ''}]]></summary>
+    <content type="html"><![CDATA[${post.frontmatter.preview_image ? `<img src="${siteUrl}${post.frontmatter.preview_image}" alt="${post.frontmatter.title}" /><br/>` : ''}${post.content}]]></content>
+  </entry>`).join('')}
+</feed>`;
+
+  return feed;
+}
+
+export async function GET() {
+  try {
+    const posts = getAllPosts().slice(0, 20); // Limit to 20 most recent posts
+    const atomFeed = generateAtomFeed(posts);
+    
+    return new NextResponse(atomFeed, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/atom+xml',
+        'Cache-Control': 's-maxage=3600, stale-while-revalidate',
+      },
+    });
+  } catch (error) {
+    console.error('Error generating Atom feed:', error);
+    return new NextResponse('Error generating Atom feed', { status: 500 });
+  }
+}

--- a/next-app/api/rss/route.js
+++ b/next-app/api/rss/route.js
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+
+const postsDirectory = path.join(process.cwd(), 'content/posts');
+
+function getAllPosts() {
+  const slugs = fs.readdirSync(postsDirectory);
+  const posts = slugs
+    .map((slug) => {
+      const fullPath = path.join(postsDirectory, slug);
+      const fileContents = fs.readFileSync(fullPath, 'utf8');
+      const { data, content } = matter(fileContents);
+      
+      return {
+        slug: slug.replace(/\.md$/, ''),
+        frontmatter: data,
+        content,
+        fullPath,
+      };
+    })
+    .filter((post) => post.frontmatter.showInBlog !== false)
+    .sort((a, b) => new Date(b.frontmatter.date) - new Date(a.frontmatter.date));
+  
+  return posts;
+}
+
+function generateRSSFeed(posts) {
+  const siteUrl = 'https://open-elements.com';
+  const feed = `<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Open Elements</title>
+    <link>${siteUrl}</link>
+    <description>Open Source made right - Open Elements is a modern company with a clear focus on Open Source and Java</description>
+    <generator>Next.js</generator>
+    <language>en-us</language>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+    <atom:link href="${siteUrl}/api/rss" rel="self" type="application/rss+xml" />
+    ${posts.map(post => `
+    <item>
+      <title>${post.frontmatter.title}</title>
+      <link>${siteUrl}/posts/${post.frontmatter.date ? post.frontmatter.date.substring(0, 4) : ''}/${post.frontmatter.date ? post.frontmatter.date.substring(5, 7) : ''}/${post.frontmatter.date ? post.frontmatter.date.substring(8, 10) : ''}/${post.slug}/</link>
+      <pubDate>${new Date(post.frontmatter.date).toUTCString()}</pubDate>
+      <guid>${siteUrl}/posts/${post.frontmatter.date ? post.frontmatter.date.substring(0, 4) : ''}/${post.frontmatter.date ? post.frontmatter.date.substring(5, 7) : ''}/${post.frontmatter.date ? post.frontmatter.date.substring(8, 10) : ''}/${post.slug}/</guid>
+      <description><![CDATA[${post.frontmatter.excerpt || ''}]]></description>
+      ${post.frontmatter.preview_image ? `<enclosure url="${siteUrl}${post.frontmatter.preview_image}" type="image/svg+xml" />` : ''}
+    </item>`).join('')}
+  </channel>
+</rss>`;
+
+  return feed;
+}
+
+export async function GET() {
+  try {
+    const posts = getAllPosts().slice(0, 20); // Limit to 20 most recent posts
+    const rssFeed = generateRSSFeed(posts);
+    
+    return new NextResponse(rssFeed, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/rss+xml',
+        'Cache-Control': 's-maxage=3600, stale-while-revalidate',
+      },
+    });
+  } catch (error) {
+    console.error('Error generating RSS feed:', error);
+    return new NextResponse('Error generating RSS feed', { status: 500 });
+  }
+}

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "open-elements-nextjs",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "gray-matter": "^4.0.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "eslint": "^8",
+    "eslint-config-next": "14.0.0",
+    "typescript": "^5"
+  }
+}


### PR DESCRIPTION
- Implement RSS 2.0 and Atom 1.0 feed templates for Hugo
- Add Next.js API routes for migration compatibility
- Configure feed output formats in config.toml
- Support blog post metadata including preview images