### PR TITLE
feat: add sitemap parity check workflow and script

### DIFF
--- a/.github/workflows/sitemap-parity.yml
+++ b/.github/workflows/sitemap-parity.yml
@@ -1,0 +1,54 @@
+name: Sitemap Parity
+
+# Fires whenever a deployment status changes on any commit — Netlify posts one
+# of these every time it finishes a build (both PR previews and prod).
+# We only act on successful `deploy-preview` deployments and check every URL
+# listed in the current production sitemap against the freshly-deployed
+# preview. If a page in prod has become unreachable on the preview, the check
+# fails and blocks the PR.
+on:
+  deployment_status:
+
+permissions:
+  contents: read
+  # Needed so failed check runs show up on the PR conversation timeline.
+  statuses: read
+
+concurrency:
+  group: sitemap-parity-${{ github.event.deployment.sha }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    # Only run when a Netlify deploy preview has just succeeded.
+    if: >-
+      github.event.deployment_status.state == 'success' &&
+      startsWith(github.event.deployment.environment, 'deploy-preview')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code at the deployed commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.deployment.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check sitemap parity
+        env:
+          PREVIEW_URL: ${{ github.event.deployment_status.target_url }}
+        run: |
+          if [ -z "$PREVIEW_URL" ]; then
+            echo "::error::No preview URL available on this deployment_status event."
+            exit 1
+          fi
+          echo "Preview URL: $PREVIEW_URL"
+          node scripts/check-sitemap-parity.mjs \
+            --prod-base=https://open-elements.com \
+            --preview-base="$PREVIEW_URL" \
+            --concurrency=4 \
+            --retries=4

--- a/.github/workflows/sitemap-parity.yml
+++ b/.github/workflows/sitemap-parity.yml
@@ -5,10 +5,11 @@ name: Sitemap Parity
 #   - pull_request  -> waits for the Netlify deploy-preview, then checks
 #   - push to main  -> waits for the Netlify production deploy, then checks
 #
-# In both cases the job blocks until the Netlify deployment for the exact
-# commit under test reports success (via GitHub's Deployments API), then runs
-# the check against that deploy's target URL. If any prod URL is unreachable
-# on the new deploy, the check fails and blocks the merge.
+# In both cases the job blocks until Netlify posts a successful commit status
+# for the exact commit under test (Netlify integrates via the GitHub Commit
+# Status API, not the Deployments API), then runs the check against the URL
+# from that status. If any prod URL is unreachable on the new deploy, the
+# check fails and blocks the merge.
 
 on:
   pull_request:
@@ -18,7 +19,6 @@ on:
 
 permissions:
   contents: read
-  deployments: read
 
 concurrency:
   group: sitemap-parity-${{ github.event.pull_request.head.sha || github.sha }}
@@ -42,70 +42,56 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Determine expected Netlify environment
-        id: env
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "expected=deploy-preview" >> "$GITHUB_OUTPUT"
-            echo "sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "expected=production" >> "$GITHUB_OUTPUT"
-            echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Wait for Netlify deployment
         id: wait
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SHA: ${{ steps.env.outputs.sha }}
-          EXPECTED_ENV_PREFIX: ${{ steps.env.outputs.expected }}
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           # Total wait budget in seconds (default 15 min) and poll interval.
           WAIT_TIMEOUT: '900'
           WAIT_INTERVAL: '15'
         run: |
           set -euo pipefail
-          echo "Waiting for a successful Netlify deployment on commit $SHA ..."
-          echo "Expected environment prefix: $EXPECTED_ENV_PREFIX"
+          echo "Waiting for a Netlify commit status on commit $SHA ..."
 
+          # Netlify reports build status via the GitHub Commit Status API
+          # (context typically `netlify/<site-name>/deploy-preview`) rather
+          # than the Deployments API, so we poll that endpoint.
           deadline=$(( $(date +%s) + WAIT_TIMEOUT ))
           preview_url=""
 
           while [ "$(date +%s)" -lt "$deadline" ]; do
-            # List deployments GitHub knows about for this SHA. Netlify posts
-            # one per build (deploy-preview-<PR#> for PRs, production for main).
-            deployments_json=$(gh api \
-              "repos/${{ github.repository }}/deployments?sha=$SHA&per_page=100")
+            status_json=$(gh api "repos/${{ github.repository }}/commits/$SHA/status")
 
-            ids=$(printf '%s' "$deployments_json" \
-              | jq -r --arg prefix "$EXPECTED_ENV_PREFIX" \
-                '.[] | select(.environment | startswith($prefix)) | .id')
+            # Grab the first status whose context looks like a Netlify one.
+            # `map(select(...)) | .[0]` normalises the jq stream into a single
+            # (possibly null) object so downstream extraction is unambiguous.
+            netlify_state=$(printf '%s' "$status_json" | jq -r '
+              .statuses
+              | map(select(.context | ascii_downcase | startswith("netlify/")))
+              | .[0].state // ""')
+            netlify_target=$(printf '%s' "$status_json" | jq -r '
+              .statuses
+              | map(select(.context | ascii_downcase | startswith("netlify/")))
+              | .[0].target_url // ""')
 
-            for id in $ids; do
-              status_json=$(gh api \
-                "repos/${{ github.repository }}/deployments/$id/statuses?per_page=100")
-              latest_state=$(printf '%s' "$status_json" | jq -r '.[0].state // ""')
-              latest_target=$(printf '%s' "$status_json" | jq -r '.[0].target_url // ""')
-              latest_env_url=$(printf '%s' "$status_json" | jq -r '.[0].environment_url // ""')
-
-              if [ "$latest_state" = "success" ]; then
-                # Prefer environment_url (canonical site URL) over target_url
-                # (which Netlify sometimes sets to the deploy log page).
-                if [ -n "$latest_env_url" ] && [ "$latest_env_url" != "null" ]; then
-                  preview_url="$latest_env_url"
-                else
-                  preview_url="$latest_target"
-                fi
-                if [ -n "$preview_url" ] && [ "$preview_url" != "null" ]; then
-                  echo "Found successful deployment: $id -> $preview_url"
-                  break 2
-                fi
-              elif [ "$latest_state" = "failure" ] || [ "$latest_state" = "error" ]; then
-                echo "::error::Netlify deployment $id reported state=$latest_state for commit $SHA."
+            if [ "$netlify_state" = "success" ]; then
+              if [ -z "$netlify_target" ] || [ "$netlify_target" = "null" ]; then
+                echo "::error::Netlify status is success but has no target_url."
                 exit 1
               fi
-            done
+              preview_url="$netlify_target"
+              echo "Found successful Netlify deployment -> $preview_url"
+              break
+            elif [ "$netlify_state" = "failure" ] || [ "$netlify_state" = "error" ]; then
+              echo "::error::Netlify build reported state=$netlify_state for commit $SHA."
+              exit 1
+            elif [ -n "$netlify_state" ]; then
+              echo "Netlify status is currently: $netlify_state. Waiting ${WAIT_INTERVAL}s ..."
+            else
+              echo "No Netlify status posted yet. Waiting ${WAIT_INTERVAL}s ..."
+            fi
 
-            echo "No successful deployment yet, sleeping ${WAIT_INTERVAL}s ..."
             sleep "$WAIT_INTERVAL"
           done
 

--- a/.github/workflows/sitemap-parity.yml
+++ b/.github/workflows/sitemap-parity.yml
@@ -1,51 +1,125 @@
 name: Sitemap Parity
 
-# Fires whenever a deployment status changes on any commit — Netlify posts one
-# of these every time it finishes a build (both PR previews and prod).
-# We only act on successful `deploy-preview` deployments and check every URL
-# listed in the current production sitemap against the freshly-deployed
-# preview. If a page in prod has become unreachable on the preview, the check
-# fails and blocks the PR.
+# Ensures every URL currently listed in the production sitemap is still
+# reachable on the deployment that will be produced by this branch. Runs on:
+#   - pull_request  -> waits for the Netlify deploy-preview, then checks
+#   - push to main  -> waits for the Netlify production deploy, then checks
+#
+# In both cases the job blocks until the Netlify deployment for the exact
+# commit under test reports success (via GitHub's Deployments API), then runs
+# the check against that deploy's target URL. If any prod URL is unreachable
+# on the new deploy, the check fails and blocks the merge.
+
 on:
-  deployment_status:
+  pull_request:
+    branches: ['main']
+  push:
+    branches: ['main']
 
 permissions:
   contents: read
-  # Needed so failed check runs show up on the PR conversation timeline.
-  statuses: read
+  deployments: read
 
 concurrency:
-  group: sitemap-parity-${{ github.event.deployment.sha }}
+  group: sitemap-parity-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true
 
 jobs:
   check:
-    # Only run when a Netlify deploy preview has just succeeded.
-    if: >-
-      github.event.deployment_status.state == 'success' &&
-      startsWith(github.event.deployment.environment, 'deploy-preview')
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
-      - name: Checkout code at the deployed commit
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.deployment.sha }}
+          # For PRs, check out the PR head commit so the script matches what
+          # Netlify actually deployed. For pushes, this is the pushed commit.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
-      - name: Check sitemap parity
-        env:
-          PREVIEW_URL: ${{ github.event.deployment_status.target_url }}
+      - name: Determine expected Netlify environment
+        id: env
         run: |
-          if [ -z "$PREVIEW_URL" ]; then
-            echo "::error::No preview URL available on this deployment_status event."
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "expected=deploy-preview" >> "$GITHUB_OUTPUT"
+            echo "sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "expected=production" >> "$GITHUB_OUTPUT"
+            echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Wait for Netlify deployment
+        id: wait
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ steps.env.outputs.sha }}
+          EXPECTED_ENV_PREFIX: ${{ steps.env.outputs.expected }}
+          # Total wait budget in seconds (default 15 min) and poll interval.
+          WAIT_TIMEOUT: '900'
+          WAIT_INTERVAL: '15'
+        run: |
+          set -euo pipefail
+          echo "Waiting for a successful Netlify deployment on commit $SHA ..."
+          echo "Expected environment prefix: $EXPECTED_ENV_PREFIX"
+
+          deadline=$(( $(date +%s) + WAIT_TIMEOUT ))
+          preview_url=""
+
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            # List deployments GitHub knows about for this SHA. Netlify posts
+            # one per build (deploy-preview-<PR#> for PRs, production for main).
+            deployments_json=$(gh api \
+              "repos/${{ github.repository }}/deployments?sha=$SHA&per_page=100")
+
+            ids=$(printf '%s' "$deployments_json" \
+              | jq -r --arg prefix "$EXPECTED_ENV_PREFIX" \
+                '.[] | select(.environment | startswith($prefix)) | .id')
+
+            for id in $ids; do
+              status_json=$(gh api \
+                "repos/${{ github.repository }}/deployments/$id/statuses?per_page=100")
+              latest_state=$(printf '%s' "$status_json" | jq -r '.[0].state // ""')
+              latest_target=$(printf '%s' "$status_json" | jq -r '.[0].target_url // ""')
+              latest_env_url=$(printf '%s' "$status_json" | jq -r '.[0].environment_url // ""')
+
+              if [ "$latest_state" = "success" ]; then
+                # Prefer environment_url (canonical site URL) over target_url
+                # (which Netlify sometimes sets to the deploy log page).
+                if [ -n "$latest_env_url" ] && [ "$latest_env_url" != "null" ]; then
+                  preview_url="$latest_env_url"
+                else
+                  preview_url="$latest_target"
+                fi
+                if [ -n "$preview_url" ] && [ "$preview_url" != "null" ]; then
+                  echo "Found successful deployment: $id -> $preview_url"
+                  break 2
+                fi
+              elif [ "$latest_state" = "failure" ] || [ "$latest_state" = "error" ]; then
+                echo "::error::Netlify deployment $id reported state=$latest_state for commit $SHA."
+                exit 1
+              fi
+            done
+
+            echo "No successful deployment yet, sleeping ${WAIT_INTERVAL}s ..."
+            sleep "$WAIT_INTERVAL"
+          done
+
+          if [ -z "$preview_url" ]; then
+            echo "::error::Timed out after ${WAIT_TIMEOUT}s waiting for a Netlify deployment on $SHA."
             exit 1
           fi
+
+          echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
+
+      - name: Check sitemap parity
+        env:
+          PREVIEW_URL: ${{ steps.wait.outputs.preview_url }}
+        run: |
           echo "Preview URL: $PREVIEW_URL"
           node scripts/check-sitemap-parity.mjs \
             --prod-base=https://open-elements.com \

--- a/content/posts/2011-07-15-jgrid-netbeans-platform-certified-training.md
+++ b/content/posts/2011-07-15-jgrid-netbeans-platform-certified-training.md
@@ -4,6 +4,7 @@ showInBlog: false
 title: 'JGrid @ NetBeans Platform Certified Training'
 date: "2011-07-15"
 author: hendrik
+slug: jjjjjjjjjjjfsdfsdfsdfadfafasdfasf
 categories: [Swing]
 excerpt: 'Together with Geertjan Wielenga from Oracle I will introduce the jGrid-Component and its integration into a NetBeans Platform app'
 preview_image: "/posts/preview-images/software-development-green.svg"

--- a/content/posts/2011-07-15-jgrid-netbeans-platform-certified-training.md
+++ b/content/posts/2011-07-15-jgrid-netbeans-platform-certified-training.md
@@ -4,7 +4,6 @@ showInBlog: false
 title: 'JGrid @ NetBeans Platform Certified Training'
 date: "2011-07-15"
 author: hendrik
-slug: jjjjjjjjjjjfsdfsdfsdfadfafasdfasf
 categories: [Swing]
 excerpt: 'Together with Geertjan Wielenga from Oracle I will introduce the jGrid-Component and its integration into a NetBeans Platform app'
 preview_image: "/posts/preview-images/software-development-green.svg"

--- a/scripts/check-sitemap-parity.mjs
+++ b/scripts/check-sitemap-parity.mjs
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+/**
+ * Verify that every URL currently listed in the production sitemap is still
+ * reachable on a preview deployment (typically a Netlify PR preview).
+ *
+ * How it works:
+ *   1. Downloads `${prodBase}/en/sitemap.xml` and `${prodBase}/de/sitemap.xml`
+ *      and extracts every `<loc>` URL.
+ *   2. For each URL, keeps only the path (+ query, if any) and requests
+ *      `${previewBase}${path}` with redirect following. A final 2xx response
+ *      is a pass; anything else (3xx-terminal, 4xx, 5xx, network error) is a
+ *      fail.
+ *   3. Also downloads the preview's own `/en/sitemap.xml` and `/de/sitemap.xml`
+ *      and reports which production paths are missing from them (informational
+ *      — a path can be missing from the preview sitemap and still reachable,
+ *      which the reachability check catches separately).
+ *
+ * Usage:
+ *   node scripts/check-sitemap-parity.mjs \
+ *     --preview-base=https://deploy-preview-42--my-site.netlify.app \
+ *     [--prod-base=https://open-elements.com] \
+ *     [--concurrency=8] \
+ *     [--timeout=15000]
+ *
+ * Exits 0 if every prod URL is reachable on the preview, 1 otherwise.
+ */
+
+const DEFAULT_PROD_BASE = 'https://open-elements.com';
+const LOCALES = ['en', 'de'];
+const USER_AGENT =
+  'Mozilla/5.0 (compatible; open-elements-sitemap-parity/1.0; +https://github.com/open-elements/open-elements-website)';
+const RETRY_STATUSES = new Set([403, 408, 425, 429, 500, 502, 503, 504]);
+
+function parseArgs(argv) {
+  const out = {
+    prodBase: DEFAULT_PROD_BASE,
+    previewBase: null,
+    concurrency: 4,
+    timeoutMs: 15000,
+    retries: 3,
+  };
+  for (const arg of argv.slice(2)) {
+    if (arg.startsWith('--prod-base=')) {
+      out.prodBase = arg.slice('--prod-base='.length);
+    } else if (arg.startsWith('--preview-base=')) {
+      out.previewBase = arg.slice('--preview-base='.length);
+    } else if (arg.startsWith('--concurrency=')) {
+      out.concurrency = Number(arg.slice('--concurrency='.length));
+    } else if (arg.startsWith('--timeout=')) {
+      out.timeoutMs = Number(arg.slice('--timeout='.length));
+    } else if (arg.startsWith('--retries=')) {
+      out.retries = Number(arg.slice('--retries='.length));
+    } else if (arg === '--help' || arg === '-h') {
+      out.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return out;
+}
+
+function stripTrailingSlash(url) {
+  return url.replace(/\/+$/, '');
+}
+
+async function fetchText(url, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      redirect: 'follow',
+      signal: controller.signal,
+      headers: { 'user-agent': USER_AGENT },
+    });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} ${res.statusText} for ${url}`);
+    }
+    return await res.text();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function extractLocs(xml) {
+  const locs = [];
+  const re = /<loc>([^<]+)<\/loc>/g;
+  let m;
+  while ((m = re.exec(xml)) !== null) {
+    locs.push(m[1].trim());
+  }
+  return locs;
+}
+
+function urlToPath(rawUrl) {
+  try {
+    const u = new URL(rawUrl);
+    return `${u.pathname}${u.search}`;
+  } catch {
+    return null;
+  }
+}
+
+async function loadSitemapPaths(base, timeoutMs) {
+  const paths = new Set();
+  for (const locale of LOCALES) {
+    const sitemapUrl = `${base}/${locale}/sitemap.xml`;
+    const xml = await fetchText(sitemapUrl, timeoutMs);
+    for (const loc of extractLocs(xml)) {
+      const p = urlToPath(loc);
+      if (p) paths.add(p);
+    }
+  }
+  return paths;
+}
+
+async function checkReachable(previewBase, pathAndQuery, timeoutMs, retries) {
+  const target = `${previewBase}${pathAndQuery}`;
+  let lastStatus = 0;
+  let lastError;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    if (attempt > 0) {
+      const backoffMs = 500 * 2 ** (attempt - 1);
+      await new Promise(resolve => setTimeout(resolve, backoffMs));
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(target, {
+        redirect: 'follow',
+        signal: controller.signal,
+        headers: { 'user-agent': USER_AGENT },
+      });
+      if (res.ok) {
+        return {
+          ok: true,
+          status: res.status,
+          finalUrl: res.url,
+          attempts: attempt + 1,
+        };
+      }
+      lastStatus = res.status;
+      if (!RETRY_STATUSES.has(res.status)) {
+        return { ok: false, status: res.status, attempts: attempt + 1 };
+      }
+    } catch (err) {
+      lastError = err.message ?? String(err);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  return {
+    ok: false,
+    status: lastStatus,
+    error: lastError,
+    attempts: retries + 1,
+  };
+}
+
+async function runWithConcurrency(items, concurrency, worker) {
+  const results = new Array(items.length);
+  let cursor = 0;
+  const runners = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    async () => {
+      while (true) {
+        const i = cursor++;
+        if (i >= items.length) return;
+        results[i] = await worker(items[i], i);
+      }
+    },
+  );
+  await Promise.all(runners);
+  return results;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help || !args.previewBase) {
+    console.error(
+      'Usage: node scripts/check-sitemap-parity.mjs --preview-base=<url> [--prod-base=<url>] [--concurrency=N] [--timeout=ms]',
+    );
+    process.exit(args.help ? 0 : 2);
+  }
+
+  const prodBase = stripTrailingSlash(args.prodBase);
+  const previewBase = stripTrailingSlash(args.previewBase);
+
+  console.log(`Prod base:    ${prodBase}`);
+  console.log(`Preview base: ${previewBase}`);
+  console.log(`Concurrency:  ${args.concurrency}`);
+  console.log('');
+
+  console.log('Downloading production sitemaps...');
+  const prodPaths = await loadSitemapPaths(prodBase, args.timeoutMs);
+  console.log(`  ${prodPaths.size} unique paths in production sitemap.`);
+
+  console.log('Downloading preview sitemaps (informational)...');
+  let previewPaths = new Set();
+  try {
+    previewPaths = await loadSitemapPaths(previewBase, args.timeoutMs);
+    console.log(`  ${previewPaths.size} unique paths in preview sitemap.`);
+  } catch (err) {
+    console.warn(
+      `  WARN: failed to fetch preview sitemap (${err.message ?? err}). ` +
+        'Continuing with reachability check only.',
+    );
+  }
+
+  const missingFromPreviewSitemap = [...prodPaths].filter(
+    p => previewPaths.size > 0 && !previewPaths.has(p),
+  );
+  if (missingFromPreviewSitemap.length > 0) {
+    console.log('');
+    console.log(
+      `Paths in prod sitemap but NOT in preview sitemap (${missingFromPreviewSitemap.length}):`,
+    );
+    for (const p of missingFromPreviewSitemap) console.log(`  - ${p}`);
+  }
+
+  console.log('');
+  console.log(`Checking reachability of ${prodPaths.size} paths on preview...`);
+
+  const pathList = [...prodPaths].sort();
+  const results = await runWithConcurrency(
+    pathList,
+    args.concurrency,
+    async pathAndQuery => {
+      const r = await checkReachable(
+        previewBase,
+        pathAndQuery,
+        args.timeoutMs,
+        args.retries,
+      );
+      return { pathAndQuery, ...r };
+    },
+  );
+
+  const failures = results.filter(r => !r.ok);
+  const okCount = results.length - failures.length;
+
+  console.log('');
+  console.log(`Reachable: ${okCount} / ${results.length}`);
+
+  if (failures.length > 0) {
+    console.log('');
+    console.log(`Broken paths (${failures.length}):`);
+    for (const f of failures) {
+      const detail =
+        f.error != null ? `error: ${f.error}` : `status: ${f.status}`;
+      console.log(`  ✗ ${f.pathAndQuery}  (${detail})`);
+    }
+    process.exit(1);
+  }
+
+  console.log('');
+  console.log('All production URLs are reachable on the preview. ✓');
+}
+
+main().catch(err => {
+  console.error(err.stack ?? err.message ?? err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Decription

Introduces a new automated workflow to ensure that all URLs listed in the production sitemap remain reachable in preview deployments, preventing accidental removals of important pages. It adds a GitHub Actions workflow that waits for a Netlify deployment to complete, then runs a new Node.js script to check sitemap parity between production and preview environments.

**Sitemap parity check automation:**

* Added `.github/workflows/sitemap-parity.yml` to run on pull requests and pushes to `main`. This workflow waits for a successful Netlify deployment, then verifies that every URL in the production sitemap is reachable on the preview deployment. If any URL is unreachable, the check fails and blocks the merge.
* Introduced `scripts/check-sitemap-parity.mjs`, a Node.js script that:
  * Downloads and parses the production and preview sitemaps.
  * Checks that all production URLs are reachable on the preview deployment, with support for concurrency, retries, and timeouts.
  * Reports any missing or broken URLs, exiting with a nonzero status if any are found.


## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 Style/formatting
- [ ] ♻️ Refactor
- [ ] 🔧 Configuration
- [ ] ⚡ Performance
- [ ] 🧪 Tests
- [ ] 🔐 Security


## Changes Made
- Change 1
- Change 2
- Change 3

## How to Test
1. Step 1
2. Step 2
3. Verify the expected behavior

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review conducted
- [ ] Comments added for complex logic
- [ ] Documentation updated (if needed)
- [ ] No new warnings generated
- [ ] Tests added/updated (if applicable)
- [ ] All tests passing locally
