### PR TITLE
chore: publish Maven monthly updates (MAY 2026,JUNE 2026)

### DIFF
--- a/src/data/de/updates-maven.json
+++ b/src/data/de/updates-maven.json
@@ -1,5 +1,166 @@
 [
   {
+    "month": "JUNE",
+    "year": 2026,
+    "excerpt": "Abhängigkeits‑Schwachstellen‑Überwachung, Arbeit am buildinfo des Maven Artifact‑Plugins, Surefire und 3.10.0 Vorbereitung, erste atr-maven-plugin‑Veröffentlichung und Getting Started‑Dokumentation",
+    "categories": [
+      {
+        "title": "Lieferkettensicherheit",
+        "items": [
+          {
+            "text": "Verbesserung der Abhängigkeits‑Schwachstellen‑Überwachung für die Apache Maven Projektfamilie",
+            "type": "SECURITY"
+          },
+          {
+            "text": "Analyse des Maven Artifact‑Plugins, um Verbesserungen bei der buildinfo‑Erstellung und dem Build‑Vergleich zu erzielen",
+            "type": "IMPROVEMENT"
+          },
+          {
+            "text": "Entfernen der veralteten Bereitstellungsfunktion für buildinfo‑Dateien aus dem Maven Artifact‑Plugin",
+            "type": "MAINTENANCE"
+          }
+        ]
+      },
+      {
+        "title": "Wartung",
+        "items": [
+          {
+            "text": "Beheben von Problemen des neuen Surefire‑Modus, der ausschließlich die JUnit‑Plattform verwendet",
+            "type": "BUG_FIX"
+          },
+          {
+            "text": "Vorbereitung der Veröffentlichung 3.10.0",
+            "type": "MAINTENANCE"
+          },
+          {
+            "text": "Vorbereitung des Upgrades von Release Drafter von 6.x auf 7.x",
+            "type": "MAINTENANCE"
+          }
+        ]
+      },
+      {
+        "title": "Modernisierung zentraler Funktionen",
+        "items": [
+          {
+            "text": "Arbeiten am atr-maven-plugin, um den Release‑Prozess mit dem ATR (Apache Trusted Releases)-Dienst zu unterstützen; erste Veröffentlichung des Plugins",
+            "type": "FEATURE"
+          },
+          {
+            "text": "Migration von JUnit‑3‑basierten Tests, die AbstractMojoTestCase verwenden, zu JUnit 5 im Maven Changelog‑Plugin",
+            "type": "IMPROVEMENT"
+          }
+        ]
+      },
+      {
+        "title": "Dokumentation",
+        "items": [
+          {
+            "text": "Erstellung der Getting Started‑Dokumentation",
+            "type": "DOCUMENTATION"
+          },
+          {
+            "text": "Erstellung eines Schreibleitfadens für Dokumentation im Allgemeinen",
+            "type": "DOCUMENTATION"
+          }
+        ]
+      }
+    ],
+    "contributors": [
+      "https://github.com/slawekjaranowski",
+      "https://github.com/Ndacyayisenga-droid",
+      "https://github.com/sparsick",
+      "https://github.com/sebtiem",
+      "https://github.com/olamy"
+    ]
+  },
+  {
+    "month": "MAY",
+    "year": 2026,
+    "excerpt": "Fortschritt beim Maven 3.10.0 Release-Train, CycloneDX- und buildinfo-Verbesserungen, ATR-Release-Tools und Getting Started-Dokumentation",
+    "categories": [
+      {
+        "title": "Lieferkettensicherheit",
+        "items": [
+          {
+            "text": "Verbesserung der buildinfo-Dateibehandlung für Multimodulprojektes",
+            "type": "IMPROVEMENT",
+            "link": "https://github.com/apache/maven-artifact-plugin/issues/93"
+          },
+          {
+            "text": "Verbesserung der CycloneDX 1.7 ECMA-Spezifikationsimplementierung für Java",
+            "type": "SECURITY"
+          }
+        ]
+      },
+      {
+        "title": "Wartung",
+        "items": [
+          {
+            "text": "Der Release-Train für 3.10.0 wurde gestartet, indem Features aus dem 4.x‑Zweig zurückportiert wurden",
+            "type": "MAINTENANCE"
+          },
+          {
+            "text": "Testen und Beheben des 3.10.0 Release-Trains",
+            "type": "MAINTENANCE"
+          },
+          {
+            "text": "Überprüfung und Korrektur von ASF‑gepflegten Maven‑Plugins mit 3.10.0",
+            "type": "MAINTENANCE"
+          },
+          {
+            "text": "Veröffentlichung von Maven 3.9.16 mit Fehlerbehebungen",
+            "type": "BUG_FIX"
+          }
+        ]
+      },
+      {
+        "title": "Modernisierung zentraler Funktionen",
+        "items": [
+          {
+            "text": "Werkzeug zur Automatisierung des lokalen Release‑Prozesses für Apache Maven",
+            "type": "IMPROVEMENT"
+          },
+          {
+            "text": "Arbeiten am atr-maven-plugin, um den Release‑Prozess mit dem ATR (Apache Trusted Releases)-Dienst zu unterstützen",
+            "type": "FEATURE"
+          }
+        ]
+      },
+      {
+        "title": "Dokumentation",
+        "items": [
+          {
+            "text": "Vorschlag für den Inhalt von \"Getting Started\" ausarbeiten",
+            "type": "DOCUMENTATION"
+          },
+          {
+            "text": "Konzeption für Lernpfade ausarbeiten",
+            "type": "DOCUMENTATION"
+          },
+          {
+            "text": "Getting Started‑Dokumentationsinhalt initialisiert",
+            "type": "DOCUMENTATION"
+          },
+          {
+            "text": "Umfassende Reviews der ersten beiden \"Getting Started\"‑PRs",
+            "type": "DOCUMENTATION"
+          },
+          {
+            "text": "Diskussion über globale Schreibstile, z. B. die Ansprache des Lesers in formeller oder informeller Weise",
+            "type": "DOCUMENTATION"
+          }
+        ]
+      }
+    ],
+    "contributors": [
+      "https://github.com/slawekjaranowski",
+      "https://github.com/Ndacyayisenga-droid",
+      "https://github.com/sparsick",
+      "https://github.com/sebtiem",
+      "https://github.com/olamy"
+    ]
+  },
+  {
     "month": "APRIL",
     "year": 2026,
     "excerpt": "Fokus auf Verbesserungen der Sicherheit in der Lieferkette, Vorbereitung von Maven 3.10.0 und Beginn einer besseren Tool-Unterstützung für den internen Release-Prozess von Apache Maven",

--- a/src/data/en/updates-maven.json
+++ b/src/data/en/updates-maven.json
@@ -1,5 +1,166 @@
 [
   {
+    "month": "JUNE",
+    "year": 2026,
+    "excerpt": "Dependency vulnerability monitoring, Maven Artifact plugin buildinfo work, Surefire and 3.10.0 prep, first atr-maven-plugin release, and Getting Started docs",
+    "categories": [
+      {
+        "title": "Security of the Supply Chain",
+        "items": [
+          {
+            "type": "SECURITY",
+            "text": "Improve dependency vulnerability monitoring for the Apache Maven project family"
+          },
+          {
+            "type": "IMPROVEMENT",
+            "text": "Analyze Maven Artifact plugin to make improvements for buildinfo generation and build comparison"
+          },
+          {
+            "type": "MAINTENANCE",
+            "text": "Remove deprecated deployment feature for buildinfo files from Maven Artifact plugin"
+          }
+        ]
+      },
+      {
+        "title": "Maintenance",
+        "items": [
+          {
+            "type": "BUG_FIX",
+            "text": "Fixing issues of new Surefire mode using JUnit Platform only"
+          },
+          {
+            "type": "MAINTENANCE",
+            "text": "Preparing release 3.10.0"
+          },
+          {
+            "type": "MAINTENANCE",
+            "text": "Preparing for upgrade of Release Drafter from 6.x to 7.x"
+          }
+        ]
+      },
+      {
+        "title": "Modernization of Core Features",
+        "items": [
+          {
+            "type": "FEATURE",
+            "text": "Working on atr-maven-plugin to support the release process with ATR (Apache Trusted Releases) service; first release of the plugin"
+          },
+          {
+            "type": "IMPROVEMENT",
+            "text": "Migration of JUnit 3 based tests that use AbstractMojoTestCase to JUnit 5 in Maven Changelog plugin"
+          }
+        ]
+      },
+      {
+        "title": "Documentation",
+        "items": [
+          {
+            "type": "DOCUMENTATION",
+            "text": "Authoring Getting Started documentation"
+          },
+          {
+            "type": "DOCUMENTATION",
+            "text": "Starting a writing guide for documentation in general"
+          }
+        ]
+      }
+    ],
+    "contributors": [
+      "https://github.com/slawekjaranowski",
+      "https://github.com/Ndacyayisenga-droid",
+      "https://github.com/sparsick",
+      "https://github.com/sebtiem",
+      "https://github.com/olamy"
+    ]
+  },
+  {
+    "month": "MAY",
+    "year": 2026,
+    "excerpt": "Progress on Maven 3.10.0 release train, CycloneDX and buildinfo improvements, ATR release tooling, and Getting Started documentation",
+    "categories": [
+      {
+        "title": "Security of the Supply Chain",
+        "items": [
+          {
+            "type": "IMPROVEMENT",
+            "text": "Improve buildinfo-file handling for multimodule projects",
+            "link": "https://github.com/apache/maven-artifact-plugin/issues/93"
+          },
+          {
+            "type": "SECURITY",
+            "text": "Improve on CycloneDX 1.7 ECMA specification implementation for Java"
+          }
+        ]
+      },
+      {
+        "title": "Maintenance",
+        "items": [
+          {
+            "type": "MAINTENANCE",
+            "text": "Release train for 3.10.0 has been started with backporting features from 4.x branch"
+          },
+          {
+            "type": "MAINTENANCE",
+            "text": "Testing and fixing of the 3.10.0 release train"
+          },
+          {
+            "type": "MAINTENANCE",
+            "text": "Check and fix ASF maintained Maven plugins with 3.10.0"
+          },
+          {
+            "type": "BUG_FIX",
+            "text": "Release Maven 3.9.16 with bug fixes"
+          }
+        ]
+      },
+      {
+        "title": "Modernization of Core Features",
+        "items": [
+          {
+            "type": "IMPROVEMENT",
+            "text": "Tool to automate the local release process for Apache Maven"
+          },
+          {
+            "type": "FEATURE",
+            "text": "Working on atr-maven-plugin to support the release process with ATR (Apache Trusted Releases) service"
+          }
+        ]
+      },
+      {
+        "title": "Documentation",
+        "items": [
+          {
+            "type": "DOCUMENTATION",
+            "text": "Draw up suggestion for \"Getting Started\" content"
+          },
+          {
+            "type": "DOCUMENTATION",
+            "text": "Draw up conception for learning paths"
+          },
+          {
+            "type": "DOCUMENTATION",
+            "text": "Getting Started docs content initialized"
+          },
+          {
+            "type": "DOCUMENTATION",
+            "text": "Extensive reviews of first two \"Getting Started\" PRs"
+          },
+          {
+            "type": "DOCUMENTATION",
+            "text": "Discussion about global writing styles, e.g. addressing the reader in a formal or informal way"
+          }
+        ]
+      }
+    ],
+    "contributors": [
+      "https://github.com/slawekjaranowski",
+      "https://github.com/Ndacyayisenga-droid",
+      "https://github.com/sparsick",
+      "https://github.com/sebtiem",
+      "https://github.com/olamy"
+    ]
+  },
+  {
     "month": "APRIL",
     "year": 2026,
     "excerpt": "Focus on security supply-chain improvements, Maven 3.10.0 preparation and starting better tooling support for Apache Maven internal release process",


### PR DESCRIPTION
## Summary
- Publish Maven monthly updates for **MAY 2026,JUNE 2026** to `/updates/maven`
- Generated from English-only structured reports in `support-and-care/maven-support-and-care`
- German text is a **Mittwald AI draft** created during automation

## Review focus
- [ ] German copy reviewed by a native speaker or someone who understands German
- [ ] Preview EN and DE entries for MAY 2026,JUNE 2026 on `/updates/maven`
- [ ] Confirm types, links, excerpts, and contributors look correct

## Source
- Commit: `1b85663fd91fd6974c4e2e98660c51ef99f72a56`
- Workflow run: https://github.com/support-and-care/maven-support-and-care/actions/runs/29958433867