### PR TITLE
feat: enhance internal link localization for blog posts and standard pages

### DIFF
--- a/docs/04-adding-blog-post.md
+++ b/docs/04-adding-blog-post.md
@@ -98,12 +98,15 @@ Write markdown below the front matter. Keep heading structure consistent between
 
 Internal link rules:
 
-- Standard pages:
-  - EN: `/about`, `/contact`
-  - DE: `/de/about`, `/de/contact`
-- Blog posts:
-  - EN: `/posts/YYYY/MM/DD/<slug>`
-  - DE: `/de/posts/YYYY/MM/DD/<slug>`
+- Write internal links **locale-neutral**, without the `/de` prefix — the renderer adds the
+  prefix of the post's locale automatically (see `localizeInternalLinks()` in
+  [src/lib/markdown.ts](../src/lib/markdown.ts)).
+- Standard pages: `/about`, `/contact`
+- Blog posts: `/posts/YYYY/MM/DD/<slug>`
+
+Already existing `/de/...` links keep working — the rewriter never double-prefixes. External
+links, anchors (`#…`), `mailto:`/`tel:` and asset paths (`/images/foo.png`) stay untouched.
+A link to a post that only exists in English also stays unprefixed so it does not 404.
 
 Do not use `/blog/...` in new content. The active route is `/posts/...`.
 Do not link to the legacy `/posts/<filename>` alias in new content either — use the canonical `/posts/YYYY/MM/DD/<slug>` form.

--- a/src/app/[locale]/[...rest]/page.tsx
+++ b/src/app/[locale]/[...rest]/page.tsx
@@ -6,6 +6,7 @@ import { notFound, redirect } from 'next/navigation';
 import { remark } from 'remark';
 import remarkGfm from 'remark-gfm';
 import html from 'remark-html';
+import { localizeInternalLinks } from '@/lib/markdown';
 import { transformHugoShortcodes } from '@/lib/remark-hugo-shortcodes';
 
 type CatchAllPageProps = {
@@ -95,7 +96,7 @@ async function loadPageData(
     title: typeof data.title === 'string' ? data.title : 'Open Elements',
     description:
       typeof data.description === 'string' ? data.description : undefined,
-    contentHtml: processedContent.toString(),
+    contentHtml: localizeInternalLinks(processedContent.toString(), locale),
   };
 }
 

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -39,6 +39,11 @@ const INTERNAL_HOSTNAMES = new Set([
   '::1',
 ]);
 
+const DEFAULT_LOCALE = 'en';
+const LOCALE_PATH_PREFIXES = new Set(['en', 'de']);
+// Root-relative targets that end in a file extension are assets, not routes.
+const ASSET_PATH_PATTERN = /\.[a-z0-9]{2,5}$/i;
+
 const EXTERNAL_LINK_ICON_HTML =
   '<span class="iconify inline" data-icon="mdi-open-in-new" aria-hidden="true"></span>';
 const HEADING_ANCHOR_ICON_HTML =
@@ -338,6 +343,62 @@ function isExternalContentLink(href: string): boolean {
   } catch {
     return false;
   }
+}
+
+function localizeInternalHref(href: string, locale: string): string {
+  const normalizedHref = href.trim();
+
+  // Only root-relative links are locale-scoped; protocol-relative URLs are external.
+  if (!normalizedHref.startsWith('/') || normalizedHref.startsWith('//')) {
+    return href;
+  }
+
+  const [, pathname, suffix] = /^([^?#]*)([\s\S]*)$/.exec(normalizedHref) ?? [];
+
+  if (pathname === undefined) {
+    return href;
+  }
+
+  const firstSegment = pathname.split('/')[1] ?? '';
+
+  if (LOCALE_PATH_PREFIXES.has(firstSegment)) {
+    return href;
+  }
+
+  if (ASSET_PATH_PATTERN.test(pathname)) {
+    return href;
+  }
+
+  const normalizedPathname = pathname.replace(/\/+$/, '');
+
+  // A post that only exists in the default locale must stay unprefixed, otherwise
+  // the localized URL would 404.
+  const postSlugPath = /^\/posts\/(.+)$/.exec(normalizedPathname)?.[1];
+
+  if (postSlugPath && !postExistsForLocale(postSlugPath, locale)) {
+    return href;
+  }
+
+  return `/${locale}${normalizedPathname}${suffix ?? ''}`;
+}
+
+/**
+ * Rewrite locale-neutral internal links so they resolve within the rendered locale.
+ * Authors write `/posts/2025/12/15/foo`; a German page renders `/de/posts/2025/12/15/foo`.
+ */
+export function localizeInternalLinks(
+  contentHtml: string,
+  locale: string,
+): string {
+  if (locale === DEFAULT_LOCALE) {
+    return contentHtml;
+  }
+
+  return contentHtml.replace(
+    /(<a\b[^>]*?\bhref=)(["'])(.*?)\2/gi,
+    (_fullMatch, beforeHref: string, quote: string, href: string) =>
+      `${beforeHref}${quote}${localizeInternalHref(href, locale)}${quote}`,
+  );
 }
 
 function ensureBlankTarget(attributes: string): string {
@@ -723,7 +784,10 @@ export async function getPostBySlug(
     const contentHtml = highlightCodeBlocks(
       decorateHeadlinesWithAnchors(
         decorateExternalLinks(
-          centerStandaloneHtmlImages(processedContent.toString()),
+          localizeInternalLinks(
+            centerStandaloneHtmlImages(processedContent.toString()),
+            locale,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
This pull request introduces a locale-aware system for internal links in markdown-rendered content. Authors now write internal links without a locale prefix, and the renderer automatically adds the correct locale prefix based on the current page's locale. This ensures that links resolve correctly for both English and German content, prevents double-prefixing, and leaves external links, anchors, and asset paths unchanged.

**Locale-aware internal link handling:**

* Added the `localizeInternalLinks` function in `src/lib/markdown.ts` to rewrite locale-neutral internal links so they resolve within the rendered locale, using the correct `/de/` or `/en/` prefix as needed.
* Updated the markdown processing pipeline to apply `localizeInternalLinks` after HTML conversion, ensuring all internal links in page content are correctly localized (`getPostBySlug` in `src/lib/markdown.ts`, [src/lib/markdown.tsR787-R790](diffhunk://#diff-368adcabee5a8d0ea03ea643bda8c22e2b2dc502d83909c620ee49646066b103R787-R790); `loadPageData` in `src/app/[locale]/[...rest]/page.tsx`, [src/app/[locale]/[...rest]/page.tsxL98-R99](diffhunk://#diff-d18a9160af7d5c8ba904b787fe994f120ebdc5272d9dc28073ebfab680df63edL98-R99); import added, [src/app/[locale]/[...rest]/page.tsxR9](diffhunk://#diff-d18a9160af7d5c8ba904b787fe994f120ebdc5272d9dc28073ebfab680df63edR9))

**Documentation updates:**

* Updated internal link rules in `docs/04-adding-blog-post.md` to instruct authors to write locale-neutral internal links and describe the new automatic locale prefixing behavior.

**Supporting constants and patterns:**

* Added constants for default locale, supported locale prefixes, and asset path detection in `src/lib/markdown.ts` to support the new link rewriting logic.